### PR TITLE
Switch from KEYS to SCAN command

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -18,5 +18,8 @@
   },
   "pauseOnError": "INDEXER_DELAY_ON_ERROR",
   "port": "PORT",
-  "redisUrl": "REDIS_URL"
+  "redis": {
+    "scanCount": "REDIS_SCAN_COUNT",
+    "url": "REDIS_URL"
+  }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -26,6 +26,9 @@
   "newRelic": {},
   "pauseOnError": 2000,
   "port": 3005,
-  "redisUrl": "redis://localhost:6379",
+  "redis": {
+    "scanCount": 100,
+    "url": "redis://localhost:6379"
+  },
   "subscriptionTimeout": 120000
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8475,6 +8475,11 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
       "integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "debug": "3.1.0",
     "lodash": "4.17.10",
     "newrelic": "4.1.3",
+    "p-defer": "1.0.0",
     "p-memoize": "1.0.0",
     "promise-all-props": "1.0.1",
     "promise-prototype-finally": "1.0.0",
@@ -33,8 +34,8 @@
     "restify-router": "0.5.0",
     "socket.io": "2.1.1",
     "time-bombs": "1.0.0",
-    "web3-utils": "1.0.0-beta.34",
     "web3": "1.0.0-beta.34",
+    "web3-utils": "1.0.0-beta.34",
     "winston": "2.4.2",
     "winston-papertrail": "1.0.5",
     "winston-sentry-transport": "1.0.0"


### PR DESCRIPTION
Current implementation uses `KEYS tok:<address>:*` command to retrieve all tokens related to an address. Redis recommends not using `KEYS` in production for performance issues and use `SCAN` instead.

This PR redefines the `db.keys()` function so it is implemented internally using the iterative approach required by `SCAN` while keeping the interface with no changes.